### PR TITLE
Fix dev build and tslint warnings

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -8,7 +8,6 @@ var
   projectRoot = path.resolve(__dirname, '../'),
   ProgressBarPlugin = require('progress-bar-webpack-plugin'),
   CopyWebpackPlugin = require('copy-webpack-plugin'),
-  SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin'),
   useCssSourceMap =
     (env.dev && config.dev.cssSourceMap) ||
     (env.prod && config.build.productionSourceMap)
@@ -100,12 +99,6 @@ module.exports = {
         to: path.resolve(__dirname, '../dist')
       }
     ], {}),
-    new SWPrecacheWebpackPlugin({
-      cacheId: 'my-quasar-app',
-      filename: 'service-worker.js',
-      minify: false,
-      stripPrefix: 'dist/'
-    }),
     new webpack.DefinePlugin({
       'process.env': config[env.prod ? 'build' : 'dev'].env,
       'DEV': env.dev,

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -5,6 +5,7 @@ var
   webpack = require('webpack'),
   merge = require('webpack-merge'),
   baseWebpackConfig = require('./webpack.base.conf'),
+  SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin'),
   ExtractTextPlugin = require('extract-text-webpack-plugin'),
   HtmlWebpackPlugin = require('html-webpack-plugin'),
   OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
@@ -19,6 +20,12 @@ module.exports = merge(baseWebpackConfig, {
   },
   devtool: config.build.productionSourceMap ? '#source-map' : false,
   plugins: [
+    new SWPrecacheWebpackPlugin({
+      cacheId: 'my-quasar-app',
+      filename: 'service-worker.js',
+      minify: false,
+      stripPrefix: 'dist/'
+    }),
     new webpack.optimize.UglifyJsPlugin({
       sourceMap: config.build.productionSourceMap,
       minimize: true,

--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -32,12 +32,12 @@ export default class App extends Vue {
             // updatefound is also fired the very first time the SW is installed
             if (isServiceWorkerInstalled) {
               // The updatefound event implies that registration.installing is set
-              const installingWorker = registration.installing;
+              const installingWorker = registration.installing
               installingWorker!.onstatechange = function() {
                 switch (installingWorker!.state) {
                   case 'installed':
                     Toast.create.positive('New content is available, please reload.')
-                    break;
+                    break
                   case 'redundant':
                     throw new Error('The installing service worker became redundant.')
                 }


### PR DESCRIPTION
`quasar dev` failed because dist directory didn't exist. This PR completely moves the service-worker generator plugin to production only, it's not useful in dev mode.

Also fixes two tslint warnings